### PR TITLE
Fix superbuild errors on Ubuntu-isnan

### DIFF
--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -392,6 +392,11 @@ char * strdup (char *instr);
 #  define CPLIsInf(x) (!_isnan(x) && !_finite(x))
 #  define CPLIsFinite(x) _finite(x)
 #else
+#  include <math.h>
+#  ifdef __cplusplus
+#    include <cmath>
+using std::isnan;
+#  endif
 #  define CPLIsNan(x) isnan(x)
 #  ifdef isinf 
 #    define CPLIsInf(x) isinf(x)


### PR DESCRIPTION
Fix error as "`isnan` is not defined within the scope" when building
cmb-superbuild on Ubuntu 16.04 with GCC 5.4.1. Since isnan is
defined differently in <math.h> and <cmath>.
