### PR TITLE
Avoid redefining snprintf for VS2015

### DIFF
--- a/port/cpl_config.h.vc
+++ b/port/cpl_config.h.vc
@@ -14,10 +14,14 @@
 #define HAVE_VPRINTF 1
 #define HAVE_VSNPRINTF 1
 #define HAVE_SNPRINTF 1
-#if defined(_MSC_VER) && (_MSC_VER < 1500)
-#  define vsnprintf _vsnprintf
+#if defined(_MSC_VER)
+#  if (_MSC_VER < 1500)
+#    define vsnprintf _vsnprintf
+#  endif
+#  if (_MSC_VER < 1900)
+#    define snprintf _snprintf
+#  endif
 #endif
-#define snprintf _snprintf
 
 #define HAVE_GETCWD 1
 /* gmt_notunix.h from GMT project also redefines getcwd. See #3138 */


### PR DESCRIPTION
Prior to VS2015, only _snprintf was defined. Now, snprintf is
defined. This commit prevents the redefinition of snprintf when
using VS2015.